### PR TITLE
Handle fractional NTP seconds

### DIFF
--- a/firmware/SparkTime.cpp
+++ b/firmware/SparkTime.cpp
@@ -376,6 +376,7 @@ bool SparkTime::isEuroDST(uint32_t tnow) {
 void SparkTime::updateNTPTime() {
   //digitalWrite(D7,HIGH);
   _isSyncing = true;
+  RGB.color(255,255,0);
   _UDPClient->begin(_localPort);
   memset(_packetBuffer, 0, SPARKTIMENTPSIZE); 
   _packetBuffer[0] = 0b11100011;   // LI, Version, Mode
@@ -411,6 +412,9 @@ void SparkTime::updateNTPTime() {
     _lastSyncMillisTime = localmsec;
     _lastSyncMillisTime -= ((_lastSyncNTPFrac >> 10) * 1000) >> 22;	// (_lastSyncNTPFrac * 1000) >> 32
     _syncedOnce = true;
+    RGB.color(0,255,0);
+  } else {
+    RGB.color(255,0,0);
   }
   //digitalWrite(D7,LOW);
   _UDPClient->stop();  

--- a/firmware/SparkTime.cpp
+++ b/firmware/SparkTime.cpp
@@ -409,6 +409,7 @@ void SparkTime::updateNTPTime() {
     _lastSyncNTPTime = _packetBuffer[40] << 24 | _packetBuffer[41] << 16 | _packetBuffer[42] << 8 | _packetBuffer[43];
     _lastSyncNTPFrac = _packetBuffer[44] << 24 | _packetBuffer[45] << 16 | _packetBuffer[46] << 8 | _packetBuffer[47];
     _lastSyncMillisTime = localmsec;
+    _lastSyncMillisTime -= ((_lastSyncNTPFrac >> 10) * 1000) >> 22;	// (_lastSyncNTPFrac * 1000) >> 32
     _syncedOnce = true;
   }
   //digitalWrite(D7,LOW);


### PR DESCRIPTION
Adjust _lastSyncMillisTime by the fractional NTP part into the past to the beginning of the current second.
